### PR TITLE
Mobile Optimizations 

### DIFF
--- a/css/components/nav.css
+++ b/css/components/nav.css
@@ -55,6 +55,7 @@
     border-radius: 0.5rem;
     box-shadow: 0 1px 0.5rem 0 rgba(0, 0, 102, 0.5);
     transition: transform 200ms ease;
+    width: fit-content;
 }
 .nav .nav__actions .nav__cta:hover:not(:active) {
     transform: translateY(-2px);

--- a/css/pages/list.css
+++ b/css/pages/list.css
@@ -64,7 +64,7 @@
     display: flex;
     justify-content: space-evenly;
     text-align: center;
-    gap: 2rem;
+    gap: auto;
 }
 .page-list .level-container .level .stats li {
     display: flex;


### PR DESCRIPTION
this fixes two visual bugs on mobile devices, tldr it makes the submit record button not contain a line break by extending the button width to the text, and for the level stats it sets the gap between tables to “auto” which stops the word “points” from being cut off.

 i don’t have access to a pc rn so if something here is bugged on desktop let me know here or on discord. make sure my fork is synced before pushing :)