### PR TITLE
add info box saying challenge list is archived, also fix accessibilit…

### DIFF
--- a/css/components/nav.css
+++ b/css/components/nav.css
@@ -63,6 +63,9 @@
 .nav .nav__actions .nav__cta:hover:not(:active) {
     transform: translateY(-2px);
 }
+.nav__actions2 {
+    margin-bottom: 30px;
+}
 .nav .nav__actions2 {
     flex: 1;
     display: flex;

--- a/css/pages/list.css
+++ b/css/pages/list.css
@@ -126,3 +126,13 @@
 .page-list .meta .editors li a:hover {
     text-decoration: underline;
 }
+.notice {
+    border: 4px solid var(--color-primary);
+    font: inherit;
+    padding: 1.3rem;
+    color: var(--color-on-background) !important;
+    border-radius: 0.5rem;
+    box-shadow: 0 1px 0.5rem 0 rgba(0, 0, 102, 0.5);
+    margin:5px;
+    text-align:center;
+}

--- a/js/pages/ChallengeLeaderboard.js
+++ b/js/pages/ChallengeLeaderboard.js
@@ -42,7 +42,9 @@ export default {
                             </router-link>
                         </div>
                     </nav>
-                    <h1>‎ </h1>
+                    <div class="notice" style="margin:22px">
+                        <p>The challenge list has been archived as of 7/20/24. No new layouts or records will be added.</p>
+                    </div>
                     <table class="board">
                         <tr v-for="(ientry, i) in leaderboard">
                             <td class="rank">

--- a/js/pages/ChallengeLeaderboard.js
+++ b/js/pages/ChallengeLeaderboard.js
@@ -42,7 +42,7 @@ export default {
                             </router-link>
                         </div>
                     </nav>
-                    <div class="notice" style="margin:22px">
+                    <div class="notice" style="margin-bottom:22px">
                         <p>The challenge list has been archived as of 7/20/24. No new layouts or records will be added.</p>
                     </div>
                     <table class="board">

--- a/js/pages/ChallengeLeaderboard.js
+++ b/js/pages/ChallengeLeaderboard.js
@@ -42,7 +42,7 @@ export default {
                             </router-link>
                         </div>
                     </nav>
-                    <div class="notice" style="margin-bottom:22px;margin-top:-15px">
+                    <div class="notice" style="margin-bottom:22px;margin-top:-12px">
                         <p>The challenge list has been archived as of 7/20/24. No new layouts or records will be added.</p>
                     </div>
                     <table class="board">

--- a/js/pages/ChallengeLeaderboard.js
+++ b/js/pages/ChallengeLeaderboard.js
@@ -42,7 +42,7 @@ export default {
                             </router-link>
                         </div>
                     </nav>
-                    <div class="notice" style="margin-bottom:22px">
+                    <div class="notice" style="margin-bottom:22px;margin-top:-15px">
                         <p>The challenge list has been archived as of 7/20/24. No new layouts or records will be added.</p>
                     </div>
                     <table class="board">

--- a/js/pages/ChallengeList.js
+++ b/js/pages/ChallengeList.js
@@ -23,7 +23,7 @@ export default {
         <main v-else class="page-list">
             <div class="list-container">
             <nav class="nav">
-                    <div class="nav__actions2" style="margin-bottom:30px">
+                    <div class="nav__actions2">
                          <router-link class="nav__cta2" type-label-lg to="/">
                             <span class="type-label-lg">Full Levels</span>
                           </router-link>

--- a/js/pages/ChallengeList.js
+++ b/js/pages/ChallengeList.js
@@ -122,7 +122,7 @@ export default {
                     <div class="og">
                         <p class="type-label-md">Website layout on <a href="https://tsl.pages.dev/" target="_blank">TheShittyList</a>, made by DJ JDK & Blathers.</p>
                     </div>
-                    <div class="notice type-label-sm">
+                    <div class="notice type-label-sm" style="margin-top:-10">
                         <p>The challenge list has been archived as of 7/20/24. No new layouts or records will be added.</p>
                     </div>
                     <template v-if="editors">

--- a/js/pages/ChallengeList.js
+++ b/js/pages/ChallengeList.js
@@ -23,7 +23,7 @@ export default {
         <main v-else class="page-list">
             <div class="list-container">
             <nav class="nav">
-                    <div class="nav__actions2">
+                    <div class="nav__actions2" style="margin-bottom:30px">
                          <router-link class="nav__cta2" type-label-lg to="/">
                             <span class="type-label-lg">Full Levels</span>
                           </router-link>
@@ -32,7 +32,6 @@ export default {
                         </router-link>
                     </div>
                 </nav>
-                <h1>‎ </h1>
                 <table class="list" v-if="list">
                     <tr v-for="([err, rank, level], i) in list">
                         <td class="rank">
@@ -122,6 +121,9 @@ export default {
                     </div>
                     <div class="og">
                         <p class="type-label-md">Website layout on <a href="https://tsl.pages.dev/" target="_blank">TheShittyList</a>, made by DJ JDK & Blathers.</p>
+                    </div>
+                    <div class="notice type-label-sm">
+                        <p>The challenge list has been archived as of 7/20/24. No new layouts or records will be added.</p>
                     </div>
                     <template v-if="editors">
                         <h3>LIST EDITORS</h3>

--- a/js/pages/Leaderboard.js
+++ b/js/pages/Leaderboard.js
@@ -33,7 +33,7 @@ export default {
                 </div>
                 <div class="board-container">
                     <nav class="nav">
-                        <div class="nav__actions2">
+                        <div class="nav__actions2" style="margin-bottom:30px">
                              <router-link class="nav__cta2" type-label-lg to="/leaderboard">
                                 <span class="type-label-lg">Full Levels</span>
                               </router-link>
@@ -42,7 +42,6 @@ export default {
                             </router-link>
                         </div>
                     </nav>
-                    <h1>‎ </h1>
                     <table class="board">
                         <tr v-for="(ientry, i) in leaderboard">
                             <td class="rank">

--- a/js/pages/Leaderboard.js
+++ b/js/pages/Leaderboard.js
@@ -33,7 +33,7 @@ export default {
                 </div>
                 <div class="board-container">
                     <nav class="nav">
-                        <div class="nav__actions2" style="margin-bottom:30px">
+                        <div class="nav__actions2">
                              <router-link class="nav__cta2" type-label-lg to="/leaderboard">
                                 <span class="type-label-lg">Full Levels</span>
                               </router-link>

--- a/js/pages/List.js
+++ b/js/pages/List.js
@@ -23,7 +23,7 @@ export default {
         <main v-else class="page-list">
             <div class="list-container">
                 <nav class="nav">
-                    <div class="nav__actions2" style="margin-bottom:30px">
+                    <div class="nav__actions2">
                          <router-link class="nav__cta2" type-label-lg to="/">
                             <span class="type-label-lg">Full Levels</span>
                           </router-link>

--- a/js/pages/List.js
+++ b/js/pages/List.js
@@ -23,7 +23,7 @@ export default {
         <main v-else class="page-list">
             <div class="list-container">
                 <nav class="nav">
-                    <div class="nav__actions2">
+                    <div class="nav__actions2" style="margin-bottom:30px">
                          <router-link class="nav__cta2" type-label-lg to="/">
                             <span class="type-label-lg">Full Levels</span>
                           </router-link>
@@ -32,7 +32,6 @@ export default {
                         </router-link>
                     </div>
                 </nav>
-                <h1>‎ </h1>
                 <table class="list" v-if="list">
                     <tr v-for="([err, rank, level], i) in list">
                         <td class="rank">


### PR DESCRIPTION
Add a disclaimer in the challenge list and leaderboard saying that it's archived. I personally think the box on the challenge leaderboard looks bad, but i asked someone and they said it was okay so i went with it (i had no other ideas on where to put it). Additionally, this replaces the separator (a unicode character invisible to [hopefully] all browsers) with actual css formatting for the challenge list toggle, to avoid accessibility issues. 

Disclaimer on challenge list:
![image](https://github.com/user-attachments/assets/5bc74211-b4ff-46d3-abfc-9bbe78c2a033)


Disclaimer on leaderboard (ugly warning)
![image](https://github.com/user-attachments/assets/7796fad5-6bda-4b5c-a0b2-76506000c97f)




If any changes are needed, you can ask me here or on discord (you should also be able to edit my code if you want to). Make sure my fork is synced (5 commits ahead) before merging this. Thanks!